### PR TITLE
fix comparision tick calculation in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+Fix casting issue for tick calculation for RH/T compensation in Raspberry-Pi example
 
 ## [3.2.2] - 2022-12-05
 

--- a/examples/raspberry-pi/algorithm_example_usage.c
+++ b/examples/raspberry-pi/algorithm_example_usage.c
@@ -31,6 +31,7 @@
 
 #include "sensirion_gas_index_algorithm.h"
 #include <stdio.h>  // printf
+#include <math.h>
 
 #include "sensirion_common.h"
 #include "sensirion_i2c_hal.h"
@@ -66,8 +67,8 @@ void read_compensation_values(uint16_t* compensation_rh,
         // interface NOTE: in case you read RH and T raw signals check out the
         // ticks specification in the datasheet, as they can be different for
         // different sensors
-        *compensation_rh = (uint16_t)s_rh * 65535 / 100;
-        *compensation_t = (uint16_t)(s_temperature + 45) * 65535 / 175;
+        *compensation_rh = (uint16_t)lround(s_rh * 65535 / 100);
+        *compensation_t = (uint16_t)lround((s_temperature + 45) * 65535 / 175);
     }
 }
 

--- a/examples/raspberry-pi/low_power_example.c
+++ b/examples/raspberry-pi/low_power_example.c
@@ -31,6 +31,7 @@
 
 #include "sensirion_gas_index_algorithm.h"
 #include <stdio.h>  // printf
+#include <math.h>
 
 #include "sensirion_common.h"
 #include "sensirion_i2c_hal.h"
@@ -137,7 +138,7 @@ void read_compensation_values(uint16_t* compensation_rh,
         // NOTE: in case you read RH and T raw signals check out the
         // ticks specification in the datasheet, as they can be different for
         // different sensors
-        *compensation_rh = (uint16_t)s_rh * 65535 / 100;
-        *compensation_t = (uint16_t)(s_temperature + 45) * 65535 / 175;
+        *compensation_rh = (uint16_t)lround(s_rh * 65535 / 100);
+        *compensation_t = (uint16_t)lround((s_temperature + 45) * 65535 / 175);
     }
 }


### PR DESCRIPTION
casting operator takes precedence over the multiplication, so the old code did not had the expected outcome