### PR TITLE
Support no_std targets in Rust library

### DIFF
--- a/sensirion-gas-index-algorithm-rs/Cargo.lock
+++ b/sensirion-gas-index-algorithm-rs/Cargo.lock
@@ -3,5 +3,14 @@
 version = 4
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "sensirion-gas-index-algorithm-rs"
 version = "0.1.0"
+dependencies = [
+ "libm",
+]

--- a/sensirion-gas-index-algorithm-rs/Cargo.toml
+++ b/sensirion-gas-index-algorithm-rs/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+libm = "0.2"
+
+[features]
+default = ["std"]
+std = []

--- a/sensirion-gas-index-algorithm-rs/src/lib.rs
+++ b/sensirion-gas-index-algorithm-rs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod sensirion_gas_index_algorithm;
 #[cfg(test)]
 mod tests;

--- a/sensirion-gas-index-algorithm-rs/src/sensirion_gas_index_algorithm.rs
+++ b/sensirion-gas-index-algorithm-rs/src/sensirion_gas_index_algorithm.rs
@@ -1,3 +1,24 @@
+#[cfg(not(feature = "std"))]
+#[allow(unused)]
+trait ExtF32 {
+    fn exp(self) -> Self;
+    fn sqrt(self) -> Self;
+    fn powi(self, y: i32) -> Self;
+}
+
+#[cfg(not(feature = "std"))]
+impl ExtF32 for f32 {
+    fn exp(self) -> Self {
+        libm::expf(self)
+    }
+    fn sqrt(self) -> Self {
+        libm::sqrtf(self)
+    }
+    fn powi(self, y: i32) -> Self {
+        libm::powf(self, y as f32)
+    }
+}
+
 const DEFAULT_SAMPLING_INTERVAL: f32 = 1.0;
 const INITIAL_BLACKOUT: f32 = 45.0;
 const INDEX_GAIN: f32 = 230.0;


### PR DESCRIPTION
Some embedded targets are no_std and lack math functions for f32. This pull request adds support for these targets by using the `libm` implementation of the functions.

Tested on `target = "thumbv6m-none-eabi"`